### PR TITLE
Add Grab-style cart flow to mobile app

### DIFF
--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -14,7 +14,7 @@ export default function ProtectedLayout() {
     if (!user) {
       router.replace("/(auth)/login");
     }
-  }, [user, loading]);
+  }, [user, loading, router]);
 
   if (loading || !user) {
     return null;

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -16,6 +16,7 @@ import { useRouter } from 'expo-router';
 import { useAuth } from '../../libs/AuthContext';
 import { getFirestore, collection, query, getDocs } from 'firebase/firestore';
 import { app } from '../../libs/firebase';
+import { useCart } from '../../libs/CartContext';
 
 // --- Types ---
 type Category = { id: string; name: string; image: string; };
@@ -31,6 +32,7 @@ type Restaurant = {
 const FoodPageHeader = () => {
   const router = useRouter();
   const { user } = useAuth();
+  const { totalItems } = useCart();
 
   return (
     <SafeAreaView edges={['top']} style={styles.headerSafeArea}>
@@ -47,9 +49,23 @@ const FoodPageHeader = () => {
             <Ionicons name="chevron-down" size={16} color="#000" />
           </TouchableOpacity>
         </View>
-        <TouchableOpacity onPress={() => router.push('/(tabs)/profile')}>
-          <Ionicons name="person-circle-outline" size={32} color="#000" />
-        </TouchableOpacity>
+        <View style={styles.headerActions}>
+          <TouchableOpacity
+            onPress={() => router.push('/cart')}
+            style={styles.cartButton}
+            accessibilityLabel="Mở giỏ hàng"
+          >
+            <Ionicons name="cart-outline" size={26} color="#000" />
+            {totalItems > 0 && (
+              <View style={styles.cartBadge}>
+                <Text style={styles.cartBadgeText}>{totalItems}</Text>
+              </View>
+            )}
+          </TouchableOpacity>
+          <TouchableOpacity onPress={() => router.push('/(tabs)/profile')}>
+            <Ionicons name="person-circle-outline" size={32} color="#000" />
+          </TouchableOpacity>
+        </View>
       </View>
 
       <View style={styles.searchContainer}>
@@ -270,6 +286,31 @@ const styles = StyleSheet.create({
   addressBox: {
     flex: 1,
     marginHorizontal: 10,
+  },
+  headerActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  cartButton: {
+    padding: 4,
+  },
+  cartBadge: {
+    position: 'absolute',
+    top: -4,
+    right: -4,
+    minWidth: 18,
+    height: 18,
+    borderRadius: 9,
+    backgroundColor: '#FF3B30',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 4,
+  },
+  cartBadgeText: {
+    color: '#fff',
+    fontSize: 10,
+    fontWeight: '700',
   },
   addressTitle: {
     fontSize: 12,

--- a/mobile/app/(tabs)/payment.js
+++ b/mobile/app/(tabs)/payment.js
@@ -1,16 +1,123 @@
 // file: app/(tabs)/payment.js
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, FlatList, TouchableOpacity, Alert } from 'react-native';
+import { useRouter, useLocalSearchParams } from 'expo-router';
+import { useCart } from '../../libs/CartContext';
 
 export default function PaymentScreen() {
+    const router = useRouter();
+    const params = useLocalSearchParams();
+    const { items, totalPrice, clearCart } = useCart();
+    const rawTotal = params?.total;
+    const parsedTotal = Array.isArray(rawTotal)
+        ? Number(rawTotal[0])
+        : rawTotal !== undefined
+            ? Number(rawTotal)
+            : undefined;
+    const displayTotal = Number.isFinite(parsedTotal) ? parsedTotal : totalPrice;
+
+    const handleConfirm = () => {
+        Alert.alert('Đặt hàng thành công', 'GrabFood sẽ giao món đến bạn sớm nhất!', [
+            {
+                text: 'Tiếp tục đặt món',
+                onPress: () => {
+                    clearCart();
+                    router.push('/(tabs)/index');
+                }
+            }
+        ]);
+    };
+
     return (
         <View style={styles.container}>
-            <Text style={styles.title}>Trang Thanh Toán</Text>
+            <Text style={styles.title}>Thanh toán</Text>
+            <Text style={styles.subtitle}>Kiểm tra lại đơn hàng của bạn</Text>
+
+            <FlatList
+                data={items}
+                keyExtractor={(item) => item.id}
+                style={{ flex: 1, alignSelf: 'stretch' }}
+                contentContainerStyle={{ paddingVertical: 12 }}
+                renderItem={({ item }) => (
+                    <View style={styles.itemRow}>
+                        <View>
+                            <Text style={styles.itemName}>{item.name}</Text>
+                            <Text style={styles.itemQuantity}>Số lượng: {item.quantity}</Text>
+                        </View>
+                        <Text style={styles.itemPrice}>
+                            {(item.price * item.quantity).toLocaleString('vi-VN')}đ
+                        </Text>
+                    </View>
+                )}
+                ListEmptyComponent={
+                    <Text style={styles.emptyText}>Giỏ hàng của bạn đang trống.</Text>
+                }
+            />
+
+            <View style={styles.summaryBox}>
+                <View style={styles.summaryRow}>
+                    <Text style={styles.summaryLabel}>Tạm tính</Text>
+                    <Text style={styles.summaryValue}>{displayTotal.toLocaleString('vi-VN')}đ</Text>
+                </View>
+                <View style={styles.summaryRow}>
+                    <Text style={styles.summaryLabel}>Phí giao hàng</Text>
+                    <Text style={styles.summaryValue}>Miễn phí</Text>
+                </View>
+                <View style={[styles.summaryRow, styles.summaryTotalRow]}>
+                    <Text style={styles.summaryTotalText}>Tổng cộng</Text>
+                    <Text style={styles.summaryTotalPrice}>{displayTotal.toLocaleString('vi-VN')}đ</Text>
+                </View>
+
+                <TouchableOpacity
+                    style={[styles.confirmButton, items.length === 0 && { opacity: 0.5 }]}
+                    onPress={handleConfirm}
+                    disabled={items.length === 0}
+                >
+                    <Text style={styles.confirmText}>Xác nhận thanh toán</Text>
+                </TouchableOpacity>
+            </View>
         </View>
     );
 }
 
 const styles = StyleSheet.create({
-    container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
-    title: { fontSize: 20, fontWeight: 'bold' },
+    container: { flex: 1, padding: 20, backgroundColor: '#fff' },
+    title: { fontSize: 24, fontWeight: 'bold', marginTop: 20, alignSelf: 'flex-start' },
+    subtitle: { fontSize: 14, color: '#555', marginTop: 6, marginBottom: 12, alignSelf: 'flex-start' },
+    itemRow: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        paddingVertical: 12,
+        borderBottomWidth: 1,
+        borderBottomColor: '#f0f0f0',
+    },
+    itemName: { fontSize: 15, fontWeight: '600', color: '#111' },
+    itemQuantity: { fontSize: 13, color: '#666', marginTop: 4 },
+    itemPrice: { fontSize: 15, fontWeight: '700', color: '#00A74F' },
+    emptyText: { textAlign: 'center', color: '#777', marginTop: 24 },
+    summaryBox: {
+        paddingVertical: 16,
+        borderTopWidth: 1,
+        borderTopColor: '#e0e0e0',
+        marginTop: 12,
+    },
+    summaryRow: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        marginBottom: 10,
+    },
+    summaryLabel: { fontSize: 14, color: '#555' },
+    summaryValue: { fontSize: 15, fontWeight: '600', color: '#111' },
+    summaryTotalRow: { marginTop: 6, marginBottom: 20 },
+    summaryTotalText: { fontSize: 16, fontWeight: '700', color: '#111' },
+    summaryTotalPrice: { fontSize: 18, fontWeight: '800', color: '#00A74F' },
+    confirmButton: {
+        backgroundColor: '#00A74F',
+        paddingVertical: 14,
+        borderRadius: 28,
+        alignItems: 'center',
+    },
+    confirmText: { color: '#fff', fontSize: 16, fontWeight: '700' },
 });

--- a/mobile/app/(tabs)/profile.tsx
+++ b/mobile/app/(tabs)/profile.tsx
@@ -5,7 +5,6 @@ import {
   StyleSheet,
   ScrollView,
   TouchableOpacity,
-  Image,
   ActivityIndicator
 } from 'react-native';
 import { useAuth } from '../../libs/AuthContext';

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -3,22 +3,26 @@ import React from "react";
 import { Stack } from "expo-router";
 import { AuthProvider } from "../libs/AuthContext";
 import { SafeAreaProvider } from "react-native-safe-area-context";
+import { CartProvider } from "../libs/CartContext";
 
 export default function RootLayout() {
   return (
     <SafeAreaProvider>
       <AuthProvider>
-        <Stack screenOptions={{ headerShown: false }}>
+        <CartProvider>
+          <Stack screenOptions={{ headerShown: false }}>
           {/* Tabs (Home, Activity, Profile...) */}
           <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
 
           {/* Screens ngoài Tabs (Stack Navigation) */}
           <Stack.Screen name="restaurant/[id]" options={{ headerShown: false }} />
           <Stack.Screen name="product/[id]" options={{ headerShown: false }} />
+          <Stack.Screen name="cart/index" options={{ headerShown: false }} />
 
           {/* Auth stack (optional but recommended) */}
           <Stack.Screen name="(auth)" options={{ headerShown: false }} />
         </Stack>
+        </CartProvider>
       </AuthProvider>
     </SafeAreaProvider>
   );

--- a/mobile/app/cart/index.tsx
+++ b/mobile/app/cart/index.tsx
@@ -1,0 +1,292 @@
+import React from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  FlatList,
+  Image,
+  TouchableOpacity,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Stack, useRouter } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { useCart } from '../../libs/CartContext';
+
+const GREEN = '#00A74F';
+const BORDER = '#EEF1F1';
+
+type CartListItemProps = {
+  id: string;
+  name: string;
+  img: string;
+  price: number;
+  quantity: number;
+};
+
+const CartItemRow = ({ item }: { item: CartListItemProps }) => {
+  const { increment, decrement, removeFromCart } = useCart();
+
+  return (
+    <View style={styles.cartRow}>
+      <Image source={{ uri: item.img }} style={styles.cartImage} />
+      <View style={styles.cartInfo}>
+        <Text style={styles.cartName} numberOfLines={2}>
+          {item.name}
+        </Text>
+        <Text style={styles.cartPrice}>{item.price.toLocaleString('vi-VN')}đ</Text>
+        <View style={styles.quantityRow}>
+          <TouchableOpacity
+            onPress={() => decrement(item.id)}
+            style={styles.quantityButton}
+            accessibilityLabel="Giảm số lượng"
+          >
+            <Ionicons name="remove" size={18} color="#111" />
+          </TouchableOpacity>
+          <Text style={styles.quantityText}>{item.quantity}</Text>
+          <TouchableOpacity
+            onPress={() => increment(item.id)}
+            style={styles.quantityButton}
+            accessibilityLabel="Tăng số lượng"
+          >
+            <Ionicons name="add" size={18} color="#111" />
+          </TouchableOpacity>
+        </View>
+      </View>
+      <TouchableOpacity
+        onPress={() => removeFromCart(item.id)}
+        style={styles.removeButton}
+        accessibilityLabel="Xóa món khỏi giỏ"
+      >
+        <Ionicons name="trash-outline" size={20} color="#999" />
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+export default function CartScreen() {
+  const router = useRouter();
+  const { items, totalItems, totalPrice } = useCart();
+
+  const renderItem = ({ item }: { item: CartListItemProps }) => <CartItemRow item={item} />;
+
+  const handleCheckout = () => {
+    router.push({
+      pathname: '/(tabs)/payment',
+      params: { total: totalPrice.toString() },
+    } as never);
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <Stack.Screen options={{ headerShown: false }} />
+      <View style={styles.appBar}>
+        <TouchableOpacity
+          onPress={() => (router.canGoBack() ? router.back() : router.push('/'))}
+          style={styles.backBtn}
+        >
+          <Ionicons name="chevron-back" size={26} color="#111" />
+        </TouchableOpacity>
+        <Text style={styles.appBarTitle}>Giỏ hàng</Text>
+        <View style={{ width: 34 }} />
+      </View>
+
+      {items.length === 0 ? (
+        <View style={styles.emptyContainer}>
+          <Ionicons name="cart-outline" size={72} color="#ccc" />
+          <Text style={styles.emptyTitle}>Giỏ hàng trống</Text>
+          <Text style={styles.emptySubtitle}>
+            Bắt đầu thêm món yêu thích từ GrabFood nào!
+          </Text>
+          <TouchableOpacity
+            style={styles.emptyButton}
+            onPress={() => router.push('/(tabs)/index')}
+          >
+            <Text style={styles.emptyButtonText}>Khám phá món ngon</Text>
+          </TouchableOpacity>
+        </View>
+      ) : (
+        <>
+          <FlatList
+            data={items}
+            keyExtractor={(item) => item.id}
+            renderItem={renderItem}
+            contentContainerStyle={{ padding: 16, paddingBottom: 140 }}
+            showsVerticalScrollIndicator={false}
+          />
+
+          <View style={styles.footer}>
+            <View>
+              <Text style={styles.footerLabel}>Tổng cộng</Text>
+              <Text style={styles.footerTotal}>{totalPrice.toLocaleString('vi-VN')}đ</Text>
+              <Text style={styles.footerSub}>{totalItems} món trong giỏ</Text>
+            </View>
+            <TouchableOpacity
+              style={[styles.checkoutButton, items.length === 0 && { opacity: 0.5 }]}
+              onPress={handleCheckout}
+              disabled={items.length === 0}
+            >
+              <Text style={styles.checkoutText}>Thanh toán</Text>
+              <Ionicons name="arrow-forward" size={20} color="#fff" style={{ marginLeft: 6 }} />
+            </TouchableOpacity>
+          </View>
+        </>
+      )}
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  appBar: {
+    height: 56,
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: BORDER,
+    backgroundColor: '#fff',
+  },
+  backBtn: {
+    width: 34,
+    height: 34,
+    borderRadius: 17,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  appBarTitle: {
+    flex: 1,
+    textAlign: 'center',
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#111',
+  },
+  cartRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 12,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: BORDER,
+    marginBottom: 12,
+    backgroundColor: '#fff',
+  },
+  cartImage: {
+    width: 70,
+    height: 70,
+    borderRadius: 12,
+    backgroundColor: '#f2f4f5',
+    marginRight: 12,
+  },
+  cartInfo: {
+    flex: 1,
+  },
+  cartName: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: '#111',
+    marginBottom: 4,
+  },
+  cartPrice: {
+    fontSize: 14,
+    color: GREEN,
+    fontWeight: '700',
+  },
+  quantityRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 8,
+    gap: 10,
+  },
+  quantityButton: {
+    width: 30,
+    height: 30,
+    borderRadius: 15,
+    borderWidth: 1,
+    borderColor: BORDER,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  quantityText: {
+    minWidth: 24,
+    textAlign: 'center',
+    fontWeight: '600',
+    fontSize: 15,
+  },
+  removeButton: {
+    padding: 6,
+    marginLeft: 10,
+  },
+  emptyContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 40,
+  },
+  emptyTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    marginTop: 16,
+    color: '#222',
+  },
+  emptySubtitle: {
+    fontSize: 14,
+    color: '#777',
+    textAlign: 'center',
+    marginTop: 6,
+  },
+  emptyButton: {
+    marginTop: 24,
+    backgroundColor: GREEN,
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 22,
+  },
+  emptyButtonText: {
+    color: '#fff',
+    fontWeight: '700',
+    fontSize: 15,
+  },
+  footer: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    padding: 16,
+    borderTopWidth: 1,
+    borderTopColor: BORDER,
+    backgroundColor: '#fff',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  footerLabel: {
+    fontSize: 13,
+    color: '#666',
+  },
+  footerTotal: {
+    fontSize: 18,
+    fontWeight: '800',
+    color: GREEN,
+  },
+  footerSub: {
+    fontSize: 13,
+    color: '#555',
+    marginTop: 2,
+  },
+  checkoutButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: GREEN,
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 26,
+  },
+  checkoutText: {
+    color: '#fff',
+    fontWeight: '700',
+    fontSize: 16,
+  },
+});

--- a/mobile/app/category/[name].tsx
+++ b/mobile/app/category/[name].tsx
@@ -1,11 +1,12 @@
 // file: app/category/[name].js
 import React, { useState, useEffect } from 'react';
-import { View, Text, FlatList, StyleSheet, ActivityIndicator, Image } from 'react-native';
-import { useLocalSearchParams, Stack } from 'expo-router';
+import { View, Text, FlatList, StyleSheet, ActivityIndicator, Image, TouchableOpacity } from 'react-native';
+import { useLocalSearchParams, Stack, useRouter } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { getFirestore, collection, query, where, getDocs } from 'firebase/firestore';
 import { app } from '../../libs/firebase';
+import { useCart } from '../../libs/CartContext';
 
 // 1. Định nghĩa kiểu Product
 type Product = {
@@ -19,14 +20,16 @@ type Product = {
 };
 
 // 2. Component ProductCard (Để hiển thị sản phẩm)
-const ProductCard = ({ item }: { item: Product }) => (
-    <View style={styles.cardContainer}>
+const ProductCard = ({ item, onPress }: { item: Product; onPress: () => void }) => (
+    <TouchableOpacity style={styles.cardContainer} activeOpacity={0.9} onPress={onPress}>
         <Image source={{ uri: item.img }} style={styles.cardImagePlaceholder} />
         <View style={styles.cardInfo}>
             <Text style={styles.cardTitle}>{item.name}</Text>
             <View style={styles.cardRating}>
                 <Ionicons name="star" size={14} color="#FFC107" />
-                <Text style={styles.cardRatingText}>{item.rating} ({item.reviews} đánh giá)</Text>
+                <Text style={styles.cardRatingText}>
+                    {(item.rating ?? 4.5).toFixed(1)} ({item.reviews ?? 0} đánh giá)
+                </Text>
             </View>
             <View style={styles.cardPriceContainer}>
                 <Text style={styles.cardPrice}>{item.price.toLocaleString('vi-VN')}đ</Text>
@@ -40,7 +43,7 @@ const ProductCard = ({ item }: { item: Product }) => (
                 </View>
             )}
         </View>
-    </View>
+    </TouchableOpacity>
 );
 
 export default function CategoryPage() {
@@ -48,6 +51,8 @@ export default function CategoryPage() {
     const { name } = useLocalSearchParams();
     const [products, setProducts] = useState<Product[]>([]);
     const [loading, setLoading] = useState(true);
+    const router = useRouter();
+    const { totalItems } = useCart();
 
     // 4. Fetch dữ liệu khi màn hình được mở
     useEffect(() => {
@@ -91,20 +96,53 @@ export default function CategoryPage() {
     return (
         <SafeAreaView style={styles.container}>
             {/* 6. Đặt tiêu đề cho trang (ví dụ: "Danh mục: Lẩu") */}
-            <Stack.Screen options={{
-                title: `Danh mục: ${name}`,
-                headerBackTitle: "Trở về"
-            }} />
+            <Stack.Screen options={{ headerShown: false }} />
+            <View style={styles.topBar}>
+                <TouchableOpacity
+                    onPress={() => (router.canGoBack() ? router.back() : router.push('/'))}
+                    style={styles.backBtn}
+                    accessibilityLabel="Quay lại"
+                >
+                    <Ionicons name="chevron-back" size={26} color="#111" />
+                </TouchableOpacity>
+                <Text style={styles.topBarTitle} numberOfLines={1}>
+                    {name}
+                </Text>
+                <TouchableOpacity
+                    onPress={() => router.push('/cart')}
+                    style={styles.cartButton}
+                    accessibilityLabel="Đi tới giỏ hàng"
+                >
+                    <Ionicons name="cart-outline" size={26} color="#111" />
+                    {totalItems > 0 && (
+                        <View style={styles.cartBadge}>
+                            <Text style={styles.cartBadgeText}>{totalItems}</Text>
+                        </View>
+                    )}
+                </TouchableOpacity>
+            </View>
 
             {loading ? (
                 <ActivityIndicator size="large" color="#00A74F" style={{ marginTop: 20 }} />
             ) : (
                 <FlatList
                     data={products}
-                    renderItem={({ item }) => <ProductCard item={item} />}
+                    renderItem={({ item }) => (
+                        <ProductCard
+                            item={item}
+                            onPress={() =>
+                                router.push({
+                                    pathname: '/product/[id]',
+                                    params: { id: item.id },
+                                } as never)
+                            }
+                        />
+                    )}
                     keyExtractor={item => item.id}
                     ListEmptyComponent={
-                        <Text style={styles.emptyText}>Không tìm thấy sản phẩm nào cho danh mục "{name}"</Text>
+                        <Text style={styles.emptyText}>
+                            {`Không tìm thấy sản phẩm nào cho danh mục "${name}"`}
+                        </Text>
                     }
                 />
             )}
@@ -117,6 +155,53 @@ const styles = StyleSheet.create({
     container: {
         flex: 1,
         backgroundColor: '#fff',
+    },
+    topBar: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        paddingHorizontal: 12,
+        paddingBottom: 8,
+        paddingTop: 4,
+        borderBottomWidth: 1,
+        borderBottomColor: '#f0f0f0',
+    },
+    backBtn: {
+        width: 34,
+        height: 34,
+        borderRadius: 17,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    topBarTitle: {
+        flex: 1,
+        textAlign: 'center',
+        fontSize: 18,
+        fontWeight: '700',
+        color: '#111',
+        paddingHorizontal: 8,
+    },
+    cartButton: {
+        width: 34,
+        height: 34,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    cartBadge: {
+        position: 'absolute',
+        top: -4,
+        right: -4,
+        minWidth: 18,
+        height: 18,
+        borderRadius: 9,
+        backgroundColor: '#FF3B30',
+        alignItems: 'center',
+        justifyContent: 'center',
+        paddingHorizontal: 4,
+    },
+    cartBadgeText: {
+        color: '#fff',
+        fontSize: 10,
+        fontWeight: '700',
     },
     emptyText: {
         textAlign: 'center',

--- a/mobile/app/product/[id].tsx
+++ b/mobile/app/product/[id].tsx
@@ -8,11 +8,13 @@ import {
   TouchableOpacity,
   ActivityIndicator,
   Platform,
+  Alert,
 } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { getFirestore, doc, getDoc } from "firebase/firestore";
 import { Ionicons } from "@expo/vector-icons";
 import { app } from "../../libs/firebase";
+import { useCart } from "../../libs/CartContext";
 
 type Product = {
   id: string;
@@ -31,6 +33,7 @@ export default function DetailProduct() {
   const router = useRouter();
   const [product, setProduct] = useState<Product | null>(null);
   const [loading, setLoading] = useState(true);
+  const { addToCart, totalItems, totalPrice } = useCart();
 
   useEffect(() => {
     const fetchProduct = async () => {
@@ -72,6 +75,18 @@ export default function DetailProduct() {
   else if (product?.restaurantId) router.push(`/restaurant/${product.restaurantId}` as never);
   else router.push("/" as never);
 };
+
+  const handleAddToCart = () => {
+    if (!product) return;
+    addToCart({
+      id: product.id,
+      name: product.name,
+      price: product.price,
+      img: product.img,
+      restaurantId: product.restaurantId,
+    });
+    Alert.alert("Đã thêm vào giỏ", `${product.name} x1`);
+  };
 
   if (loading) {
     return <ActivityIndicator size="large" color="#00A74F" style={{ marginTop: 50 }} />;
@@ -131,10 +146,24 @@ export default function DetailProduct() {
         </View>
       </ScrollView>
 
-      {/* Floating Add to Cart Button */}
-      <TouchableOpacity style={styles.floatingBtn}>
-        <Ionicons name="add" size={28} color="#fff" />
-      </TouchableOpacity>
+      <View style={styles.bottomBar}>
+        {totalItems > 0 && (
+          <TouchableOpacity
+            style={styles.viewCartButton}
+            onPress={() => router.push('/cart')}
+          >
+            <View>
+              <Text style={styles.viewCartText}>Xem giỏ hàng ({totalItems})</Text>
+              <Text style={styles.viewCartSub}>{totalPrice.toLocaleString()}đ</Text>
+            </View>
+            <Ionicons name="chevron-forward" size={20} color="#fff" />
+          </TouchableOpacity>
+        )}
+        <TouchableOpacity style={styles.addButton} onPress={handleAddToCart}>
+          <Ionicons name="cart" size={20} color="#fff" style={{ marginRight: 6 }} />
+          <Text style={styles.addButtonText}>Thêm vào giỏ</Text>
+        </TouchableOpacity>
+      </View>
     </View>
   );
 }
@@ -174,19 +203,49 @@ const styles = StyleSheet.create({
   noData: { fontSize: 16, color: "#777" },
   center: { flex: 1, justifyContent: "center", alignItems: "center" },
 
-  floatingBtn: {
+  bottomBar: {
     position: "absolute",
-    bottom: 28,
-    right: 22,
-    width: 58,
-    height: 58,
-    borderRadius: 29,
-    backgroundColor: GREEN,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    paddingHorizontal: 16,
+    paddingTop: 10,
+    paddingBottom: Platform.OS === "ios" ? 26 : 16,
+    backgroundColor: "rgba(255,255,255,0.95)",
+    borderTopWidth: 1,
+    borderTopColor: BORDER,
+    gap: 12,
+  },
+  addButton: {
+    flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
-    ...Platform.select({
-      ios: { shadowColor: "#000", shadowOpacity: 0.18, shadowRadius: 6, shadowOffset: { width: 0, height: 4 } },
-      android: { elevation: 5 },
-    }),
+    backgroundColor: GREEN,
+    paddingVertical: 14,
+    borderRadius: 28,
+  },
+  addButtonText: {
+    color: "#fff",
+    fontSize: 16,
+    fontWeight: "700",
+  },
+  viewCartButton: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    backgroundColor: "#111",
+    paddingVertical: 12,
+    paddingHorizontal: 18,
+    borderRadius: 18,
+  },
+  viewCartText: {
+    color: "#fff",
+    fontWeight: "700",
+    fontSize: 15,
+  },
+  viewCartSub: {
+    color: "#E5E5EA",
+    marginTop: 2,
+    fontSize: 13,
   },
 });

--- a/mobile/app/restaurant/[id].tsx
+++ b/mobile/app/restaurant/[id].tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import {
   View,
   Text,
@@ -14,6 +14,7 @@ import { getFirestore, collection, query, where, getDocs, doc, getDoc } from "fi
 
 import { Ionicons } from "@expo/vector-icons";
 import { app } from "../../libs/firebase";
+import { useCart } from "../../libs/CartContext";
 
 
 // ==== Types ====
@@ -37,10 +38,11 @@ type Restaurant = {
 export default function RestaurantMenu() {
   const router = useRouter();
   const { id } = useLocalSearchParams(); // restaurantId
- 
+
   const [products, setProducts] = useState<Product[]>([]);
   const [restaurant, setRestaurant] = useState<Restaurant | null>(null);
   const [loading, setLoading] = useState(true);
+  const { totalItems } = useCart();
 
   const titleText = useMemo(
     () => (restaurant?.name ? restaurant.name : "Nhà hàng"),
@@ -143,8 +145,18 @@ export default function RestaurantMenu() {
         <Text numberOfLines={1} style={styles.appBarTitle}>
           {titleText}
         </Text>
-        {/* Spacer để cân 2 bên */}
-        <View style={{ width: 34 }} />
+        <TouchableOpacity
+          onPress={() => router.push('/cart')}
+          style={styles.cartButton}
+          accessibilityLabel="Xem giỏ hàng"
+        >
+          <Ionicons name="cart-outline" size={24} color="#111" />
+          {totalItems > 0 && (
+            <View style={styles.cartBadge}>
+              <Text style={styles.cartBadgeText}>{totalItems}</Text>
+            </View>
+          )}
+        </TouchableOpacity>
       </View>
 
       {/* Header banner của nhà hàng */}
@@ -205,6 +217,30 @@ const styles = StyleSheet.create({
   },
   backBtn: { width: 34, height: 34, borderRadius: 17, alignItems: "center", justifyContent: "center" },
   appBarTitle: { flex: 1, textAlign: "center", fontSize: 18, fontWeight: "700", color: "#111" },
+  cartButton: {
+    width: 34,
+    height: 34,
+    borderRadius: 17,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  cartBadge: {
+    position: "absolute",
+    top: -4,
+    right: -4,
+    minWidth: 18,
+    height: 18,
+    borderRadius: 9,
+    backgroundColor: "#FF3B30",
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 4,
+  },
+  cartBadgeText: {
+    color: "#fff",
+    fontSize: 10,
+    fontWeight: "700",
+  },
 
   // Restaurant header
   header: {

--- a/mobile/libs/CartContext.tsx
+++ b/mobile/libs/CartContext.tsx
@@ -1,0 +1,117 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+
+export type CartItem = {
+  id: string;
+  name: string;
+  img: string;
+  price: number;
+  quantity: number;
+  restaurantId?: string;
+};
+
+export type CartContextType = {
+  items: CartItem[];
+  totalItems: number;
+  totalPrice: number;
+  addToCart: (item: Omit<CartItem, 'quantity'>, quantity?: number) => void;
+  increment: (id: string) => void;
+  decrement: (id: string) => void;
+  removeFromCart: (id: string) => void;
+  clearCart: () => void;
+};
+
+const CartContext = createContext<CartContextType | undefined>(undefined);
+
+export const CartProvider = ({ children }: { children: React.ReactNode }) => {
+  const [items, setItems] = useState<CartItem[]>([]);
+
+  const addToCart = useCallback((item: Omit<CartItem, 'quantity'>, quantity = 1) => {
+    if (quantity <= 0) return;
+
+    setItems((prev) => {
+      const existing = prev.find((cartItem) => cartItem.id === item.id);
+      if (existing) {
+        return prev.map((cartItem) =>
+          cartItem.id === item.id
+            ? { ...cartItem, quantity: cartItem.quantity + quantity }
+            : cartItem
+        );
+      }
+
+      return [
+        ...prev,
+        {
+          ...item,
+          quantity,
+        },
+      ];
+    });
+  }, []);
+
+  const increment = useCallback((id: string) => {
+    setItems((prev) =>
+      prev.map((item) =>
+        item.id === id ? { ...item, quantity: item.quantity + 1 } : item
+      )
+    );
+  }, []);
+
+  const decrement = useCallback((id: string) => {
+    setItems((prev) =>
+      prev
+        .map((item) =>
+          item.id === id
+            ? { ...item, quantity: Math.max(0, item.quantity - 1) }
+            : item
+        )
+        .filter((item) => item.quantity > 0)
+    );
+  }, []);
+
+  const removeFromCart = useCallback((id: string) => {
+    setItems((prev) => prev.filter((item) => item.id !== id));
+  }, []);
+
+  const clearCart = useCallback(() => setItems([]), []);
+
+  const totals = useMemo(() => {
+    return items.reduce(
+      (acc, item) => {
+        acc.totalItems += item.quantity;
+        acc.totalPrice += item.quantity * item.price;
+        return acc;
+      },
+      { totalItems: 0, totalPrice: 0 }
+    );
+  }, [items]);
+
+  const value = useMemo(
+    () => ({
+      items,
+      addToCart,
+      increment,
+      decrement,
+      removeFromCart,
+      clearCart,
+      totalItems: totals.totalItems,
+      totalPrice: totals.totalPrice,
+    }),
+    [items, totals, addToCart, increment, decrement, removeFromCart, clearCart]
+  );
+
+  return <CartContext.Provider value={value}>{children}</CartContext.Provider>;
+};
+
+export const useCart = () => {
+  const context = useContext(CartContext);
+  if (!context) {
+    throw new Error('useCart must be used within a CartProvider');
+  }
+  return context;
+};


### PR DESCRIPTION
## Summary
- add a CartContext and provider to manage cart state across the app
- build a dedicated cart screen with quantity controls and checkout CTA
- wire the cart into product, category, restaurant, home, and payment experiences

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d864f8900833292f12144e385d0ff)