### PR TITLE
Enhance mobile checkout address flow and product quantity

### DIFF
--- a/mobile/app/(tabs)/activity.tsx
+++ b/mobile/app/(tabs)/activity.tsx
@@ -21,7 +21,7 @@ import { useAuth } from '../../libs/AuthContext';
 import { app } from '../../libs/firebase';
 
 const STATUS_META: Record<string, { label: string; color: string; icon: keyof typeof Ionicons.glyphMap }> = {
-  pending: { label: 'Đang xử lý', color: '#F59E0B', icon: 'time-outline' },
+  pending: { label: 'Chờ xử lý', color: '#F59E0B', icon: 'time-outline' },
   confirmed: { label: 'Đã xác nhận', color: '#3B82F6', icon: 'checkmark-done-outline' },
   delivering: { label: 'Đang giao', color: '#00A74F', icon: 'bicycle-outline' },
   completed: { label: 'Hoàn tất', color: '#10B981', icon: 'checkmark-circle-outline' },

--- a/mobile/app/checkout/payment.tsx
+++ b/mobile/app/checkout/payment.tsx
@@ -15,17 +15,27 @@ import {
     PanResponder,
     KeyboardAvoidingView,
     Platform,
+    Alert,
+    Switch,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { router } from "expo-router";
 import { app } from "../../libs/firebase";
 import { useCart } from "../../libs/CartContext";
+import { useAuth } from "../../libs/AuthContext";
 import {
     getFirestore,
     collection,
     getDocs,
     query,
     where,
+    addDoc,
+    serverTimestamp,
+    onSnapshot,
+    orderBy,
+    doc,
+    writeBatch,
+    getDoc,
 } from "firebase/firestore";
 
 // ===== Types & Utils =====
@@ -42,6 +52,46 @@ type PaymentMethod = "momo" | "bank" | "vnpay";
 
 const VND = (v: number) =>
     (Number(v) || 0).toLocaleString("vi-VN", { minimumFractionDigits: 0 }) + "đ";
+
+type AddressItem = {
+    id: string;
+    label?: string;
+    detail: string;
+    note?: string;
+    contactName?: string;
+    phone?: string;
+    isDefault?: boolean;
+    fromProfile?: boolean;
+};
+
+type NewAddressForm = {
+    label: string;
+    detail: string;
+    note: string;
+    contactName: string;
+    phone: string;
+    isDefault: boolean;
+};
+
+const composeAddressLine = (addr: AddressItem) => {
+    const parts = [addr.label?.trim(), addr.detail.trim()].filter(Boolean);
+    const base = parts.join(" • ");
+    if (addr.note) {
+        return `${base} (${addr.note.trim()})`;
+    }
+    return base;
+};
+
+const buildOrderAddress = (addr: AddressItem) => {
+    const segments = [composeAddressLine(addr)];
+    if (addr.contactName) {
+        segments.push(`Người nhận: ${addr.contactName}`);
+    }
+    if (addr.phone) {
+        segments.push(`SĐT: ${addr.phone}`);
+    }
+    return segments.filter(Boolean).join(" | ");
+};
 
 const screenH = Dimensions.get("window").height;
 
@@ -168,14 +218,37 @@ const SwipeableCartRow: React.FC<SwipeItemProps> = ({ p, onDelete }) => {
 // ===== Main Screen =====
 export default function PaymentScreen() {
     const { items, totalPrice, addToCart, clearCart, removeFromCart } = useCart();
+    const { user, updateUser } = useAuth();
     const restaurantId = items[0]?.restaurantId ?? null;
 
     const db = useMemo(() => getFirestore(app), []);
+    const defaultContactName = useMemo(() => {
+        const fullName = [user?.firstname, user?.lastname].filter(Boolean).join(" ").trim();
+        return fullName || user?.username || "";
+    }, [user?.firstname, user?.lastname, user?.username]);
+    const defaultPhone = useMemo(() => user?.phonenumber ?? "", [user?.phonenumber]);
+
     const [menu, setMenu] = useState<Product[]>([]);
     const [loadingMenu, setLoadingMenu] = useState(false);
     const [search, setSearch] = useState("");
 
     const [payment, setPayment] = useState<PaymentMethod>("momo");
+    const [restaurantInfo, setRestaurantInfo] = useState<{ name: string; address?: string } | null>(null);
+
+    const [addresses, setAddresses] = useState<AddressItem[]>([]);
+    const [addressLoading, setAddressLoading] = useState(false);
+    const [selectedAddressId, setSelectedAddressId] = useState<string | null>(null);
+    const [addressSheetMode, setAddressSheetMode] = useState<"list" | "form">("list");
+    const [newAddressForm, setNewAddressForm] = useState<NewAddressForm>({
+        label: "",
+        detail: "",
+        note: "",
+        contactName: defaultContactName,
+        phone: defaultPhone,
+        isDefault: true,
+    });
+    const [savingAddress, setSavingAddress] = useState(false);
+    const [placingOrder, setPlacingOrder] = useState(false);
 
     // Undo snackbar
     const [undoItem, setUndoItem] = useState<null | {
@@ -186,6 +259,148 @@ export default function PaymentScreen() {
     // BottomSheets
     const addSheet = useBottomSheet(false);
     const paySheet = useBottomSheet(false, Math.min(420, screenH * 0.6));
+    const addressSheet = useBottomSheet(false, Math.min(520, screenH * 0.82));
+
+    const profileAddress = useMemo<AddressItem | null>(() => {
+        if (!user?.address) return null;
+        return {
+            id: "__profile",
+            label: "Địa chỉ hiện tại",
+            detail: user.address,
+            contactName: defaultContactName,
+            phone: defaultPhone,
+            isDefault: addresses.length === 0,
+            fromProfile: true,
+        };
+    }, [user?.address, defaultContactName, defaultPhone, addresses.length]);
+
+    const combinedAddresses = useMemo(() => {
+        const list = [...addresses];
+        if (profileAddress) {
+            list.unshift(profileAddress);
+        }
+        return list;
+    }, [addresses, profileAddress]);
+
+    const selectedAddress = useMemo(() => {
+        if (!selectedAddressId) {
+            return combinedAddresses[0] ?? null;
+        }
+        return (
+            combinedAddresses.find((addr) => addr.id === selectedAddressId) ??
+            combinedAddresses[0] ??
+            null
+        );
+    }, [combinedAddresses, selectedAddressId]);
+
+    useEffect(() => {
+        if (combinedAddresses.length === 0) {
+            setSelectedAddressId(null);
+            return;
+        }
+        const hasCurrent = combinedAddresses.some((addr) => addr.id === selectedAddressId);
+        if (!hasCurrent) {
+            const defaultAddr = combinedAddresses.find((addr) => addr.isDefault) ?? combinedAddresses[0];
+            if (defaultAddr) {
+                setSelectedAddressId(defaultAddr.id);
+            }
+        }
+    }, [combinedAddresses, selectedAddressId]);
+
+    useEffect(() => {
+        setNewAddressForm((prev) => ({
+            ...prev,
+            contactName: prev.contactName || defaultContactName,
+            phone: prev.phone || defaultPhone,
+        }));
+    }, [defaultContactName, defaultPhone]);
+
+    useEffect(() => {
+        if (!addressSheet.open) {
+            setAddressSheetMode("list");
+        }
+    }, [addressSheet.open]);
+
+    const resetNewAddressForm = useCallback(() => {
+        setNewAddressForm({
+            label: "",
+            detail: "",
+            note: "",
+            contactName: defaultContactName,
+            phone: defaultPhone,
+            isDefault: addresses.length === 0,
+        });
+    }, [addresses.length, defaultContactName, defaultPhone]);
+
+    useEffect(() => {
+        if (!user?.id) {
+            setAddresses([]);
+            setAddressLoading(false);
+            setSelectedAddressId(null);
+            return;
+        }
+
+        setAddressLoading(true);
+        const addressesRef = collection(db, "users", user.id, "addresses");
+        const q = query(addressesRef, orderBy("createdAt", "desc"));
+
+        const unsubscribe = onSnapshot(
+            q,
+            (snapshot) => {
+                const mapped: AddressItem[] = snapshot.docs
+                    .map((docSnap) => {
+                        const data = docSnap.data() as any;
+                        const detail = (data.detail ?? data.address ?? "").toString().trim();
+                        if (!detail) return null;
+                        return {
+                            id: docSnap.id,
+                            label: data.label ?? data.title ?? "",
+                            detail,
+                            note: data.note ?? "",
+                            contactName: data.contactName ?? data.recipient ?? "",
+                            phone: data.phone ?? data.phoneNumber ?? "",
+                            isDefault: Boolean(data.isDefault),
+                        } as AddressItem;
+                    })
+                    .filter((addr): addr is AddressItem => Boolean(addr));
+
+                setAddresses(mapped);
+                setAddressLoading(false);
+            },
+            (error) => {
+                console.warn("Không thể tải địa chỉ:", error);
+                setAddresses([]);
+                setAddressLoading(false);
+            }
+        );
+
+        return () => unsubscribe();
+    }, [db, user?.id]);
+
+    useEffect(() => {
+        if (!restaurantId) {
+            setRestaurantInfo(null);
+            return;
+        }
+
+        const fetchRestaurant = async () => {
+            try {
+                const ref = doc(db, "restaurants", restaurantId);
+                const snap = await getDoc(ref);
+                if (snap.exists()) {
+                    const data = snap.data() as any;
+                    setRestaurantInfo({ name: data.name ?? data.title ?? "GrabFood", address: data.address });
+                } else {
+                    setRestaurantInfo(null);
+                }
+            } catch (error) {
+                console.warn("Không thể tải thông tin nhà hàng:", error);
+                setRestaurantInfo(null);
+            }
+        };
+
+        fetchRestaurant();
+    }, [db, restaurantId]);
 
     // Filtered menu
     const filteredMenu = useMemo(() => {
@@ -246,15 +461,13 @@ export default function PaymentScreen() {
     // Undo
     const undoDelete = useCallback(() => {
         if (!undoItem) return;
-        for (let i = 0; i < (undoItem.quantity || 1); i++) {
-            addToCart({
-                id: undoItem.id,
-                name: undoItem.name,
-                img: undoItem.img,
-                price: undoItem.price,
-                restaurantId: undoItem.restaurantId,
-            });
-        }
+        addToCart({
+            id: undoItem.id,
+            name: undoItem.name,
+            img: undoItem.img,
+            price: undoItem.price,
+            restaurantId: undoItem.restaurantId,
+        }, undoItem.quantity || 1);
         if (undoTimer.current) clearTimeout(undoTimer.current);
         undoTimer.current = null;
         setUndoItem(null);
@@ -269,6 +482,98 @@ export default function PaymentScreen() {
     }, [items.length]);
 
     const openProduct = (id: string) => router.push(`/product/${id}`);
+
+    const openAddressSheet = useCallback(() => {
+        if (!user?.id) {
+            Alert.alert("Cần đăng nhập", "Vui lòng đăng nhập để quản lý địa chỉ giao hàng.");
+            router.push("/login");
+            return;
+        }
+        setAddressSheetMode("list");
+        addressSheet.openSheet();
+    }, [addressSheet, user?.id]);
+
+    const handleSelectAddress = useCallback(
+        async (addr: AddressItem) => {
+            setSelectedAddressId(addr.id);
+            addressSheet.closeSheet();
+            setAddressSheetMode("list");
+            if (addr.detail) {
+                try {
+                    await updateUser({ address: composeAddressLine(addr) });
+                } catch (error) {
+                    console.warn("Không thể cập nhật địa chỉ người dùng:", error);
+                }
+            }
+        },
+        [addressSheet, updateUser]
+    );
+
+    const handleSaveAddress = useCallback(async () => {
+        if (!user?.id) {
+            Alert.alert("Cần đăng nhập", "Vui lòng đăng nhập để lưu địa chỉ giao hàng.");
+            router.push("/login");
+            return;
+        }
+
+        const detail = newAddressForm.detail.trim();
+        if (!detail) {
+            Alert.alert("Thiếu thông tin", "Vui lòng nhập địa chỉ chi tiết.");
+            return;
+        }
+
+        setSavingAddress(true);
+        try {
+            const addressesRef = collection(db, "users", user.id, "addresses");
+            const payload = {
+                label: newAddressForm.label.trim(),
+                detail,
+                note: newAddressForm.note.trim(),
+                contactName: newAddressForm.contactName.trim(),
+                phone: newAddressForm.phone.trim(),
+                isDefault: newAddressForm.isDefault || addresses.length === 0,
+                createdAt: serverTimestamp(),
+            };
+
+            const docRef = await addDoc(addressesRef, payload);
+
+            if (payload.isDefault && addresses.length > 0) {
+                const batch = writeBatch(db);
+                addresses.forEach((addr) => {
+                    if (addr.id !== docRef.id) {
+                        batch.update(doc(addressesRef, addr.id), { isDefault: false });
+                    }
+                });
+                await batch.commit();
+            }
+
+            const savedAddress: AddressItem = {
+                id: docRef.id,
+                label: payload.label,
+                detail: payload.detail,
+                note: payload.note,
+                contactName: payload.contactName,
+                phone: payload.phone,
+                isDefault: payload.isDefault,
+            };
+
+            setSelectedAddressId(savedAddress.id);
+            try {
+                await updateUser({ address: composeAddressLine(savedAddress) });
+            } catch (error) {
+                console.warn("Không thể cập nhật địa chỉ mặc định:", error);
+            }
+
+            resetNewAddressForm();
+            addressSheet.closeSheet();
+            setAddressSheetMode("list");
+        } catch (error) {
+            console.error("Không thể lưu địa chỉ mới:", error);
+            Alert.alert("Lỗi", "Không thể lưu địa chỉ mới. Vui lòng thử lại.");
+        } finally {
+            setSavingAddress(false);
+        }
+    }, [user?.id, newAddressForm, addresses, db, updateUser, addressSheet, resetNewAddressForm]);
 
     const ProductRowQuick: React.FC<{ p: Product }> = ({ p }) => (
         <View style={styles.addRow}>
@@ -301,10 +606,71 @@ export default function PaymentScreen() {
         </View>
     );
 
-    const handleOrder = () => {
-        clearCart();
-        router.push("/(tabs)");
-    };
+    const handleOrder = useCallback(async () => {
+        if (items.length === 0) return;
+
+        if (!user?.id) {
+            Alert.alert("Cần đăng nhập", "Bạn cần đăng nhập để đặt hàng.");
+            router.push("/login");
+            return;
+        }
+
+        if (!selectedAddress) {
+            Alert.alert("Thiếu địa chỉ", "Vui lòng chọn hoặc thêm địa chỉ giao hàng.");
+            openAddressSheet();
+            return;
+        }
+
+        setPlacingOrder(true);
+        try {
+            const ordersRef = collection(db, "orders");
+            const orderItems = items.map((item) => ({
+                productId: item.id,
+                name: item.name,
+                price: item.price,
+                quantity: item.quantity,
+                img: item.img,
+            }));
+            const itemsCount = orderItems.reduce((sum, it) => sum + it.quantity, 0);
+            const orderCode = `GF${Date.now().toString().slice(-6).toUpperCase()}`;
+
+            await addDoc(ordersRef, {
+                userId: user.id,
+                restaurantId,
+                restaurantName: restaurantInfo?.name ?? "",
+                totalPrice,
+                paymentMethod: payment,
+                items: orderItems,
+                itemsCount,
+                status: "pending",
+                statusText: "Chờ xử lý",
+                deliveryAddress: buildOrderAddress(selectedAddress),
+                contactName: selectedAddress.contactName ?? "",
+                contactPhone: selectedAddress.phone ?? "",
+                createdAt: serverTimestamp(),
+                code: orderCode,
+            });
+
+            try {
+                await updateUser({ address: composeAddressLine(selectedAddress) });
+            } catch (error) {
+                console.warn("Không thể đồng bộ địa chỉ giao hàng:", error);
+            }
+
+            clearCart();
+            Alert.alert("Đặt hàng thành công", "Đơn hàng của bạn đang chờ xử lý.", [
+                {
+                    text: "Theo dõi đơn",
+                    onPress: () => router.replace("/(tabs)/activity"),
+                },
+            ]);
+        } catch (error) {
+            console.error("Không thể đặt đơn:", error);
+            Alert.alert("Lỗi", "Không thể đặt đơn. Vui lòng thử lại.");
+        } finally {
+            setPlacingOrder(false);
+        }
+    }, [items, user?.id, selectedAddress, openAddressSheet, db, restaurantId, restaurantInfo?.name, totalPrice, payment, updateUser, clearCart]);
 
     const total = totalPrice;
 
@@ -327,6 +693,44 @@ export default function PaymentScreen() {
                         </TouchableOpacity>
                         <Text numberOfLines={1} style={styles.headerTitle}>Thanh toán</Text>
                         <View style={{ width: 24 }} />
+                    </View>
+
+                    {/* Địa chỉ giao hàng */}
+                    <View style={styles.card}>
+                        <View style={styles.cardHeader}>
+                            <Text style={styles.cardTitle}>Giao tới</Text>
+                            <TouchableOpacity onPress={openAddressSheet}>
+                                <Text style={styles.linkGreen}>
+                                    {combinedAddresses.length > 0 ? "Thay đổi" : "Thêm mới"}
+                                </Text>
+                            </TouchableOpacity>
+                        </View>
+
+                        {addressLoading ? (
+                            <ActivityIndicator color="#00A74F" style={{ marginTop: 8 }} />
+                        ) : selectedAddress ? (
+                            <View style={styles.addressSummary}>
+                                {selectedAddress.label ? (
+                                    <Text style={styles.addressLabel}>{selectedAddress.label}</Text>
+                                ) : null}
+                                <Text style={styles.addressLine}>{selectedAddress.detail}</Text>
+                                {selectedAddress.note ? (
+                                    <Text style={styles.addressNote}>{selectedAddress.note}</Text>
+                                ) : null}
+                                <View style={styles.addressMetaRow}>
+                                    {selectedAddress.contactName ? (
+                                        <Text style={styles.addressMeta}>{selectedAddress.contactName}</Text>
+                                    ) : null}
+                                    {selectedAddress.phone ? (
+                                        <Text style={styles.addressMeta}>{selectedAddress.phone}</Text>
+                                    ) : null}
+                                </View>
+                            </View>
+                        ) : (
+                            <Text style={[styles.muted, { marginTop: 8 }]}>
+                                Bạn chưa có địa chỉ giao hàng. Thêm mới để tiếp tục đặt món.
+                            </Text>
+                        )}
                     </View>
 
                     {/* Tóm tắt đơn hàng */}
@@ -432,26 +836,191 @@ export default function PaymentScreen() {
                         <Text style={styles.footerTotal}>{VND(total)}</Text>
                     </View>
                     <TouchableOpacity
-                        style={[styles.primaryBtn, items.length === 0 && { opacity: 0.5 }]}
+                        style={[styles.primaryBtn, (items.length === 0 || placingOrder) && { opacity: 0.5 }]}
                         onPress={handleOrder}
-                        disabled={items.length === 0}
+                        disabled={items.length === 0 || placingOrder}
                     >
-                        <Text style={styles.primaryTxt}>Đặt đơn</Text>
+                        {placingOrder ? (
+                            <ActivityIndicator color="#fff" />
+                        ) : (
+                            <Text style={styles.primaryTxt}>Đặt đơn</Text>
+                        )}
                     </TouchableOpacity>
                 </View>
             </KeyboardAvoidingView>
 
             {/* Overlay */}
-            {(addSheet.open || paySheet.open) && (
+            {(addSheet.open || paySheet.open || addressSheet.open) && (
                 <TouchableOpacity
                     activeOpacity={1}
                     onPress={() => {
                         if (paySheet.open) paySheet.closeSheet();
                         if (addSheet.open) addSheet.closeSheet();
+                        if (addressSheet.open) {
+                            addressSheet.closeSheet();
+                            setAddressSheetMode("list");
+                        }
                     }}
                     style={styles.overlay}
                 />
             )}
+
+            {/* Sheet: Địa chỉ giao hàng */}
+            <Animated.View
+                style={[styles.sheet, { height: addressSheet.snapHeight, transform: [{ translateY: addressSheet.translateY }] }]}
+                {...addressSheet.pan.panHandlers}
+            >
+                <View style={styles.grabber} />
+                <View style={styles.sheetHeader}>
+                    <Text style={styles.sheetTitle}>
+                        {addressSheetMode === "list" ? "Chọn địa chỉ giao hàng" : "Thêm địa chỉ mới"}
+                    </Text>
+                    <TouchableOpacity
+                        onPress={() => {
+                            setAddressSheetMode("list");
+                            addressSheet.closeSheet();
+                        }}
+                    >
+                        <Text style={styles.sheetClose}>Đóng</Text>
+                    </TouchableOpacity>
+                </View>
+
+                {addressSheetMode === "list" ? (
+                    <ScrollView
+                        style={{ flex: 1 }}
+                        contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 24, gap: 12 }}
+                        showsVerticalScrollIndicator={false}
+                    >
+                        {addressLoading ? (
+                            <ActivityIndicator color="#00A74F" style={{ marginTop: 12 }} />
+                        ) : combinedAddresses.length === 0 ? (
+                            <View style={styles.emptyAddressBox}>
+                                <Text style={styles.muted}>Bạn chưa lưu địa chỉ nào.</Text>
+                                <TouchableOpacity
+                                    style={styles.secondaryBtn}
+                                    onPress={() => {
+                                        resetNewAddressForm();
+                                        setAddressSheetMode("form");
+                                    }}
+                                >
+                                    <Text style={styles.secondaryBtnTxt}>+ Thêm địa chỉ mới</Text>
+                                </TouchableOpacity>
+                            </View>
+                        ) : (
+                            <>
+                                {combinedAddresses.map((addr) => {
+                                    const active = selectedAddress?.id === addr.id;
+                                    return (
+                                        <TouchableOpacity
+                                            key={addr.id}
+                                            style={[styles.addressItem, active && styles.addressItemActive]}
+                                            onPress={() => handleSelectAddress(addr)}
+                                            activeOpacity={0.85}
+                                        >
+                                            <View style={[styles.radio, active && styles.radioActive]} />
+                                            <View style={{ flex: 1 }}>
+                                                {addr.label ? (
+                                                    <Text style={styles.addressItemLabel}>{addr.label}</Text>
+                                                ) : null}
+                                                <Text style={styles.addressItemDetail}>{addr.detail}</Text>
+                                                {addr.note ? (
+                                                    <Text style={styles.addressItemNote}>{addr.note}</Text>
+                                                ) : null}
+                                                <View style={styles.addressItemMetaRow}>
+                                                    {addr.contactName ? (
+                                                        <Text style={styles.addressItemMeta}>{addr.contactName}</Text>
+                                                    ) : null}
+                                                    {addr.phone ? (
+                                                        <Text style={styles.addressItemMeta}>{addr.phone}</Text>
+                                                    ) : null}
+                                                </View>
+                                                {addr.isDefault ? (
+                                                    <Text style={styles.addressBadge}>Mặc định</Text>
+                                                ) : null}
+                                            </View>
+                                        </TouchableOpacity>
+                                    );
+                                })}
+                                <TouchableOpacity
+                                    style={styles.secondaryBtn}
+                                    onPress={() => {
+                                        resetNewAddressForm();
+                                        setAddressSheetMode("form");
+                                    }}
+                                >
+                                    <Text style={styles.secondaryBtnTxt}>+ Thêm địa chỉ mới</Text>
+                                </TouchableOpacity>
+                            </>
+                        )}
+                    </ScrollView>
+                ) : (
+                    <ScrollView
+                        style={{ flex: 1 }}
+                        contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 24, gap: 12 }}
+                        showsVerticalScrollIndicator={false}
+                    >
+                        <TextInput
+                            placeholder="Ghi chú địa chỉ (ví dụ: Nhà, Công ty)"
+                            placeholderTextColor="#94A3B8"
+                            value={newAddressForm.label}
+                            onChangeText={(value) => setNewAddressForm((prev) => ({ ...prev, label: value }))}
+                            style={styles.addressInput}
+                        />
+                        <TextInput
+                            placeholder="Địa chỉ chi tiết"
+                            placeholderTextColor="#94A3B8"
+                            value={newAddressForm.detail}
+                            onChangeText={(value) => setNewAddressForm((prev) => ({ ...prev, detail: value }))}
+                            style={[styles.addressInput, { height: 80 }]}
+                            multiline
+                        />
+                        <TextInput
+                            placeholder="Ghi chú giao hàng (không bắt buộc)"
+                            placeholderTextColor="#94A3B8"
+                            value={newAddressForm.note}
+                            onChangeText={(value) => setNewAddressForm((prev) => ({ ...prev, note: value }))}
+                            style={[styles.addressInput, { height: 68 }]}
+                            multiline
+                        />
+                        <TextInput
+                            placeholder="Tên người nhận"
+                            placeholderTextColor="#94A3B8"
+                            value={newAddressForm.contactName}
+                            onChangeText={(value) => setNewAddressForm((prev) => ({ ...prev, contactName: value }))}
+                            style={styles.addressInput}
+                        />
+                        <TextInput
+                            placeholder="Số điện thoại"
+                            placeholderTextColor="#94A3B8"
+                            keyboardType="phone-pad"
+                            value={newAddressForm.phone}
+                            onChangeText={(value) => setNewAddressForm((prev) => ({ ...prev, phone: value }))}
+                            style={styles.addressInput}
+                        />
+                        <View style={styles.defaultRow}>
+                            <Text style={styles.defaultLabel}>Đặt làm địa chỉ mặc định</Text>
+                            <Switch
+                                value={newAddressForm.isDefault || addresses.length === 0}
+                                onValueChange={(value) => setNewAddressForm((prev) => ({ ...prev, isDefault: value }))}
+                                disabled={addresses.length === 0}
+                                trackColor={{ true: "#86EFAC", false: "#CBD5F5" }}
+                                thumbColor={newAddressForm.isDefault || addresses.length === 0 ? "#16A34A" : "#fff"}
+                            />
+                        </View>
+                        <TouchableOpacity
+                            style={[styles.primaryBtn, { marginTop: 4 }, savingAddress && { opacity: 0.6 }]}
+                            onPress={handleSaveAddress}
+                            disabled={savingAddress}
+                        >
+                            {savingAddress ? (
+                                <ActivityIndicator color="#fff" />
+                            ) : (
+                                <Text style={styles.primaryTxt}>Lưu địa chỉ</Text>
+                            )}
+                        </TouchableOpacity>
+                    </ScrollView>
+                )}
+            </Animated.View>
 
             {/* Sheet: Thêm món */}
             <Animated.View
@@ -561,6 +1130,12 @@ const styles = StyleSheet.create({
     cardHeader: { flexDirection: "row", justifyContent: "space-between", alignItems: "center" },
     cardTitle: { fontSize: 16, fontWeight: "800", color: "#111" },
     linkGreen: { color: "#00A74F", fontWeight: "700" },
+    addressSummary: { marginTop: 12, gap: 6 },
+    addressLabel: { fontSize: 13, fontWeight: "700", color: "#16A34A" },
+    addressLine: { fontSize: 15, fontWeight: "700", color: "#111" },
+    addressNote: { fontSize: 13, color: "#64748B" },
+    addressMetaRow: { flexDirection: "row", flexWrap: "wrap", gap: 8, marginTop: 4 },
+    addressMeta: { fontSize: 13, color: "#475569" },
 
     muted: { color: "#64748B" },
     mutedSmall: { color: "#94A3B8", fontSize: 12 },
@@ -654,6 +1229,44 @@ const styles = StyleSheet.create({
     chev: { color: "#94A3B8", fontSize: 16 },
     radio: { width: 18, height: 18, borderRadius: 9, borderWidth: 2, borderColor: "#CBD5E1" },
     radioActive: { borderColor: "#16A34A", backgroundColor: "#16A34A" },
+    emptyAddressBox: { alignItems: "center", justifyContent: "center", paddingVertical: 24, gap: 12 },
+    secondaryBtn: {
+        borderWidth: 1,
+        borderColor: "#16A34A",
+        paddingVertical: 10,
+        paddingHorizontal: 18,
+        borderRadius: 999,
+        alignItems: "center",
+    },
+    secondaryBtnTxt: { color: "#16A34A", fontWeight: "700" },
+    addressItem: {
+        flexDirection: "row",
+        alignItems: "flex-start",
+        gap: 12,
+        borderWidth: 1,
+        borderColor: "#E2E8F0",
+        borderRadius: 12,
+        padding: 12,
+        backgroundColor: "#fff",
+    },
+    addressItemActive: { borderColor: "#16A34A", backgroundColor: "#F0FFF4" },
+    addressItemLabel: { fontSize: 13, fontWeight: "700", color: "#16A34A" },
+    addressItemDetail: { fontSize: 14, fontWeight: "700", color: "#111" },
+    addressItemNote: { fontSize: 13, color: "#64748B", marginTop: 2 },
+    addressItemMetaRow: { flexDirection: "row", flexWrap: "wrap", gap: 10, marginTop: 6 },
+    addressItemMeta: { fontSize: 12, color: "#475569" },
+    addressBadge: { marginTop: 8, fontSize: 11, fontWeight: "700", color: "#16A34A" },
+    addressInput: {
+        borderWidth: 1,
+        borderColor: "#E2E8F0",
+        borderRadius: 12,
+        paddingHorizontal: 12,
+        paddingVertical: 12,
+        backgroundColor: "#F8FAFC",
+        color: "#111",
+    },
+    defaultRow: { flexDirection: "row", alignItems: "center", justifyContent: "space-between", paddingVertical: 4 },
+    defaultLabel: { fontSize: 14, color: "#111", fontWeight: "600" },
 
     // Snackbar
     snackbar: {

--- a/mobile/app/product/[id].tsx
+++ b/mobile/app/product/[id].tsx
@@ -39,6 +39,7 @@ export default function DetailProduct() {
   const router = useRouter();
   const [product, setProduct] = useState<Product | null>(null);
   const [loading, setLoading] = useState(true);
+  const [quantity, setQuantity] = useState(1);
   const { addToCart, totalItems, totalPrice } = useCart();
   const db = useMemo(() => getFirestore(app), []);
 
@@ -91,6 +92,14 @@ export default function DetailProduct() {
     router.push('/' as never);
   }, [product?.restaurantId, router]);
 
+  const incrementQuantity = useCallback(() => {
+    setQuantity((prev) => Math.min(99, prev + 1));
+  }, []);
+
+  const decrementQuantity = useCallback(() => {
+    setQuantity((prev) => (prev > 1 ? prev - 1 : 1));
+  }, []);
+
   const handleAddToCart = () => {
     if (!product) return;
     addToCart({
@@ -99,8 +108,8 @@ export default function DetailProduct() {
       price: product.price,
       img: product.img,
       restaurantId: product.restaurantId,
-    });
-    Alert.alert('Đã thêm vào giỏ', `${product.name} x1`);
+    }, quantity);
+    Alert.alert('Đã thêm vào giỏ', `${product.name} x${quantity}`);
   };
 
 
@@ -243,10 +252,32 @@ export default function DetailProduct() {
             <Ionicons name="chevron-forward" size={20} color="#fff" />
           </TouchableOpacity>
         )}
-        <TouchableOpacity style={styles.addButton} onPress={handleAddToCart}>
-          <Ionicons name="cart" size={20} color="#fff" style={{ marginRight: 6 }} />
-          <Text style={styles.addButtonText}>Thêm vào giỏ</Text>
-        </TouchableOpacity>
+        <View style={styles.buyRow}>
+          <View style={styles.quantitySelector}>
+            <TouchableOpacity
+              onPress={decrementQuantity}
+              style={[styles.quantityBtn, quantity === 1 && { opacity: 0.6 }]}
+              accessibilityLabel="Giảm số lượng"
+            >
+              <Ionicons name="remove" size={18} color="#111" />
+            </TouchableOpacity>
+            <Text style={styles.quantityValue}>{quantity}</Text>
+            <TouchableOpacity
+              onPress={incrementQuantity}
+              style={styles.quantityBtn}
+              accessibilityLabel="Tăng số lượng"
+            >
+              <Ionicons name="add" size={18} color="#111" />
+            </TouchableOpacity>
+          </View>
+          <TouchableOpacity style={styles.addButton} onPress={handleAddToCart}>
+            <Ionicons name="cart" size={20} color="#fff" style={{ marginRight: 6 }} />
+            <View>
+              <Text style={styles.addButtonText}>Thêm vào giỏ</Text>
+              <Text style={styles.addButtonSub}>{formatCurrency(product.price * quantity)}</Text>
+            </View>
+          </TouchableOpacity>
+        </View>
       </View>
     </SafeAreaView>
   );
@@ -429,6 +460,32 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
     gap: 12,
   },
+  buyRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  quantitySelector: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: '#E2E8F0',
+    backgroundColor: '#fff',
+  },
+  quantityBtn: {
+    width: 40,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  quantityValue: {
+    minWidth: 36,
+    textAlign: 'center',
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#111',
+  },
   viewCartButton: {
     backgroundColor: '#00A74F',
     borderRadius: 16,
@@ -452,14 +509,21 @@ const styles = StyleSheet.create({
     backgroundColor: '#111',
     borderRadius: 16,
     paddingVertical: 16,
+    paddingHorizontal: 16,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
+    flex: 1,
   },
   addButtonText: {
     color: '#fff',
     fontSize: 16,
     fontWeight: '700',
+  },
+  addButtonSub: {
+    color: '#CBD5F5',
+    fontSize: 12,
+    marginTop: 2,
   },
   center: {
     flex: 1,

--- a/mobile/libs/AuthContext.tsx
+++ b/mobile/libs/AuthContext.tsx
@@ -1,6 +1,9 @@
 // libs/AuthContext.tsx
 import React, { createContext, useState, useContext, ReactNode, useEffect } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { getFirestore, doc, updateDoc } from 'firebase/firestore';
+
+import { app } from './firebase';
 
 type User = {
     id: string;
@@ -17,6 +20,7 @@ type AuthContextType = {
     loading: boolean;
     login: (userData: User) => Promise<void>;
     logout: () => Promise<void>;
+    updateUser: (updates: Partial<User>) => Promise<void>;
 };
 
 const AuthContext = createContext<AuthContextType>({
@@ -24,6 +28,7 @@ const AuthContext = createContext<AuthContextType>({
     loading: true,
     login: async () => { },
     logout: async () => { },
+    updateUser: async () => { },
 });
 
 export function useAuth() {
@@ -81,8 +86,29 @@ export function AuthProvider({ children }: AuthProviderProps) {
         setLoading(false);
     };
 
+    const updateUser = async (updates: Partial<User>) => {
+        if (!user) return;
+
+        const nextUser = { ...user, ...updates };
+        setUser(nextUser);
+
+        try {
+            await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(nextUser));
+        } catch (e) {
+            console.warn('Failed to update user in storage', e);
+        }
+
+        try {
+            const db = getFirestore(app);
+            const userRef = doc(db, 'users', user.id);
+            await updateDoc(userRef, updates);
+        } catch (e) {
+            console.warn('Failed to update user profile in Firestore', e);
+        }
+    };
+
     return (
-        <AuthContext.Provider value={{ user, loading, login, logout }}>
+        <AuthContext.Provider value={{ user, loading, login, logout, updateUser }}>
             {children}
         </AuthContext.Provider>
     );

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -96,11 +96,26 @@ function App() {
     } catch {}
   }, [currentUser]);
 
-  const handleAdd = (product) => {
+  const handleAdd = (product, quantity = 1) => {
+    const safeQty = Number.isFinite(quantity) && quantity > 0 ? Math.floor(quantity) : 1;
     setCart((prev) => {
       const existing = prev.find((p) => p.id === product.id);
-      if (existing) return prev.map(p => p.id === product.id ? { ...p, quantity: p.quantity + 1 } : p);
-      return [...prev, { ...product, quantity: 1, restaurantName: product.restaurantName, restaurantId: product.restaurantId }];
+      if (existing) {
+        return prev.map((p) =>
+          p.id === product.id
+            ? { ...p, quantity: p.quantity + safeQty }
+            : p
+        );
+      }
+      return [
+        ...prev,
+        {
+          ...product,
+          quantity: safeQty,
+          restaurantName: product.restaurantName,
+          restaurantId: product.restaurantId,
+        },
+      ];
     });
   };
 

--- a/web/src/admin/components/OrdersDetail.jsx
+++ b/web/src/admin/components/OrdersDetail.jsx
@@ -40,6 +40,7 @@ export default function OrderDetail() {
             case "Đang giao bằng drone":
                 return "blue";
             case "Đang xử lý":
+            case "Chờ xử lý":
                 return "orange";
             default:
                 return "volcano";

--- a/web/src/components/Checkout.css
+++ b/web/src/components/Checkout.css
@@ -72,6 +72,146 @@
   text-transform: uppercase;
 }
 
+.address-loading {
+  margin: 0 0 12px;
+  color: #777;
+  font-style: italic;
+}
+
+.address-book {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.address-item {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 12px 14px;
+  border: 1px solid #e8e8e8;
+  border-radius: 12px;
+  background: #fafafa;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.address-item input {
+  margin-top: 4px;
+}
+
+.address-item-content {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.address-item-label {
+  font-weight: 600;
+  color: #333;
+}
+
+.address-item-value {
+  color: #555;
+  font-size: 0.95rem;
+}
+
+.address-item.active {
+  border-color: #ff7a00;
+  background: #fff5eb;
+  box-shadow: 0 4px 12px rgba(255, 122, 0, 0.12);
+}
+
+.address-empty {
+  margin: 0 0 12px;
+  color: #666;
+  font-size: 0.95rem;
+}
+
+.address-error {
+  color: #d93025;
+  margin: 4px 0 10px;
+  font-size: 0.9rem;
+}
+
+.add-address-btn {
+  margin-top: 8px;
+  padding: 10px 16px;
+  border-radius: 8px;
+  border: 1px dashed #ff7a00;
+  background: rgba(255, 122, 0, 0.08);
+  color: #ff7a00;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.add-address-btn:hover {
+  background: rgba(255, 122, 0, 0.16);
+}
+
+.new-address-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background: #fff8f2;
+  border: 1px dashed #ffb88c;
+  border-radius: 12px;
+  padding: 16px;
+  margin-top: 6px;
+}
+
+.new-address-form input,
+.new-address-form textarea {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font-size: 0.95rem;
+}
+
+.new-address-form textarea {
+  resize: vertical;
+  min-height: 70px;
+}
+
+.new-address-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.new-address-actions button {
+  flex: 1;
+  min-width: 140px;
+  padding: 10px 14px;
+  border-radius: 8px;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  background: linear-gradient(90deg, #ff7a00, #ff5400);
+  color: white;
+  transition: opacity 0.2s ease;
+}
+
+.new-address-actions button:hover {
+  opacity: 0.9;
+}
+
+.new-address-actions button.secondary {
+  background: #f0f0f0;
+  color: #555;
+  border: 1px solid #ddd;
+}
+
+.address-input-label {
+  display: block;
+  font-weight: 600;
+  margin: 16px 0 6px;
+  color: #444;
+}
+
 .store-name {
   font-size: 1.2rem;
   font-weight: 700;
@@ -181,7 +321,8 @@
 
 .checkout-form input[type="text"],
 .checkout-form input[type="tel"],
-.checkout-form input[type="email"] {
+.checkout-form input[type="email"],
+.checkout-form textarea {
   width: 100%;
   padding: 12px 15px;
   border: 1px solid #ccc;

--- a/web/src/components/Checkout.jsx
+++ b/web/src/components/Checkout.jsx
@@ -1,13 +1,13 @@
 import React, { useState, useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { collection, addDoc, doc, getDoc, serverTimestamp } from "firebase/firestore";
+import { collection, addDoc, doc, getDoc, serverTimestamp, updateDoc, arrayUnion } from "firebase/firestore";
 import { db } from "../firebase";
 import { useAuth } from "../context/AuthContext";
 import "./Checkout.css"; // Import file CSS
 
 export default function Checkout({ cart, setCart }) {
   const navigate = useNavigate();
-  const { currentUser } = useAuth();
+  const { currentUser, setCurrentUser } = useAuth();
   const total = cart.reduce((sum, item) => sum + item.price * item.quantity, 0);
   const restaurantId = cart.length > 0 ? cart[0].restaurantId : null;
 
@@ -19,6 +19,13 @@ export default function Checkout({ cart, setCart }) {
     email: "",
     address: ""
   });
+  const [savedAddresses, setSavedAddresses] = useState([]);
+  const [selectedAddressId, setSelectedAddressId] = useState(null);
+  const [isAddingAddress, setIsAddingAddress] = useState(false);
+  const [newAddress, setNewAddress] = useState("");
+  const [newAddressLabel, setNewAddressLabel] = useState("");
+  const [loadingAddresses, setLoadingAddresses] = useState(false);
+  const [addressError, setAddressError] = useState("");
   const [isProcessing, setIsProcessing] = useState(false);
 
   // Load thông tin user (giữ nguyên)
@@ -33,6 +40,73 @@ export default function Checkout({ cart, setCart }) {
       });
     }
   }, [currentUser]);
+
+  useEffect(() => {
+    const loadAddresses = async () => {
+      if (!currentUser?.uid) {
+        setSavedAddresses([]);
+        setSelectedAddressId(null);
+        return;
+      }
+
+      setLoadingAddresses(true);
+      setAddressError("");
+      try {
+        const snap = await getDoc(doc(db, "users", currentUser.uid));
+        if (!snap.exists()) {
+          setSavedAddresses([]);
+          setSelectedAddressId(null);
+          return;
+        }
+
+        const data = snap.data();
+        const addressesFromDb = Array.isArray(data.addresses) ? data.addresses : [];
+        const normalizedMap = new Map();
+
+        if (data.address && addressesFromDb.length === 0) {
+          normalizedMap.set("legacy-address", {
+            id: "legacy-address",
+            label: "Địa chỉ mặc định",
+            value: data.address,
+            isDefault: true,
+          });
+        }
+
+        addressesFromDb.forEach((addr, index) => {
+          if (!addr || !addr.value) return;
+          const id = addr.id || `saved-${index}`;
+          normalizedMap.set(id, {
+            id,
+            label: addr.label || `Địa chỉ ${index + 1}`,
+            value: addr.value,
+            isDefault: Boolean(addr.isDefault),
+          });
+        });
+
+        const normalized = Array.from(normalizedMap.values());
+        const preferred =
+          normalized.find((addr) => addr.isDefault) ||
+          normalized[0] ||
+          null;
+
+        setSavedAddresses(normalized);
+
+        if (preferred) {
+          setSelectedAddressId(preferred.id);
+          setForm((prev) => ({ ...prev, address: preferred.value }));
+        }
+      } catch (err) {
+        console.error("Lỗi tải danh sách địa chỉ:", err);
+        setAddressError("Không thể tải địa chỉ đã lưu.");
+        setSavedAddresses([]);
+        setSelectedAddressId(null);
+      } finally {
+        setLoadingAddresses(false);
+      }
+    };
+
+    loadAddresses();
+  }, [currentUser?.uid]);
 
   // Lấy thông tin nhà hàng (giữ nguyên)
   useEffect(() => {
@@ -53,6 +127,75 @@ export default function Checkout({ cart, setCart }) {
   const handleChange = (e) => {
     const { name, value } = e.target;
     setForm({ ...form, [name]: value });
+    if (name === "address") {
+      setSelectedAddressId(null);
+    }
+  };
+
+  const handleSelectAddress = (addressId) => {
+    setSelectedAddressId(addressId);
+    const found = savedAddresses.find((addr) => addr.id === addressId);
+    if (found) {
+      setForm((prev) => ({ ...prev, address: found.value }));
+    }
+    setIsAddingAddress(false);
+    setAddressError("");
+  };
+
+  const handleAddNewAddress = async () => {
+    const trimmedValue = newAddress.trim();
+    if (!trimmedValue) {
+      setAddressError("Vui lòng nhập địa chỉ mới.");
+      return;
+    }
+
+    if (!currentUser?.uid) {
+      alert("⚠️ Vui lòng đăng nhập lại để lưu địa chỉ mới.");
+      return;
+    }
+
+    const label = newAddressLabel.trim() || `Địa chỉ ${savedAddresses.length + 1}`;
+    const generatedId =
+      typeof crypto !== "undefined" && crypto.randomUUID
+        ? crypto.randomUUID()
+        : `addr-${Date.now()}`;
+
+    const addressObj = {
+      id: generatedId,
+      label,
+      value: trimmedValue,
+      isDefault: savedAddresses.length === 0,
+    };
+
+    try {
+      await updateDoc(doc(db, "users", currentUser.uid), {
+        addresses: arrayUnion(addressObj),
+        address: trimmedValue,
+      });
+
+      const updatedAddresses = [...savedAddresses, addressObj];
+      setSavedAddresses(updatedAddresses);
+      setSelectedAddressId(addressObj.id);
+      setForm((prev) => ({ ...prev, address: trimmedValue }));
+      setNewAddress("");
+      setNewAddressLabel("");
+      setIsAddingAddress(false);
+      setAddressError("");
+
+      if (typeof setCurrentUser === "function") {
+        setCurrentUser({ ...currentUser, addresses: updatedAddresses, address: trimmedValue });
+      }
+    } catch (err) {
+      console.error("Lỗi lưu địa chỉ mới:", err);
+      setAddressError("Không thể lưu địa chỉ mới. Vui lòng thử lại.");
+    }
+  };
+
+  const handleCancelNewAddress = () => {
+    setIsAddingAddress(false);
+    setNewAddress("");
+    setNewAddressLabel("");
+    setAddressError("");
   };
 
   // ✅ SỬA LỖI 1: Cải thiện hàm lấy tọa độ
@@ -96,10 +239,16 @@ export default function Checkout({ cart, setCart }) {
       return;
     }
 
+    const trimmedAddress = form.address.trim();
+    if (!trimmedAddress) {
+      alert("⚠️ Vui lòng chọn hoặc nhập địa chỉ giao hàng.");
+      return;
+    }
+
     setIsProcessing(true);
     try {
       // 1. Lấy tọa độ
-      const customerCoords = await getCoordinatesForAddress(form.address);
+      const customerCoords = await getCoordinatesForAddress(trimmedAddress);
 
       // 2. *** BƯỚC KIỂM TRA QUAN TRỌNG NHẤT ***
       // Code cũ của bạn thiếu bước này
@@ -119,7 +268,7 @@ export default function Checkout({ cart, setCart }) {
           name: `${form.lastName} ${form.firstName}`.trim(),
           phone: form.phone,
           email: form.email,
-          address: form.address,
+          address: trimmedAddress,
           latitude: customerCoords.lat, // Chắc chắn có dữ liệu
           longitude: customerCoords.lng // Chắc chắn có dữ liệu
         },
@@ -131,7 +280,7 @@ export default function Checkout({ cart, setCart }) {
           restaurantId: item.restaurantId
         })),
         total,
-        status: "Chờ xác nhận",
+        status: "Chờ xử lý",
         createdAt: serverTimestamp(),
         droneId: null
       };
@@ -179,7 +328,89 @@ export default function Checkout({ cart, setCart }) {
 
           <div className="checkout-info-block">
             <h3>GIAO ĐẾN:</h3>
-            <input type="text" name="address" value={form.address} onChange={handleChange} placeholder="Nhập địa chỉ giao hàng..." className="address-input" />
+            {loadingAddresses ? (
+              <p className="address-loading">⏳ Đang tải địa chỉ đã lưu...</p>
+            ) : (
+              <>
+                {savedAddresses.length > 0 ? (
+                  <div className="address-book">
+                    {savedAddresses.map((addr) => (
+                      <label
+                        key={addr.id}
+                        className={`address-item ${selectedAddressId === addr.id ? "active" : ""}`}
+                      >
+                        <input
+                          type="radio"
+                          name="savedAddress"
+                          value={addr.id}
+                          checked={selectedAddressId === addr.id}
+                          onChange={() => handleSelectAddress(addr.id)}
+                        />
+                        <div className="address-item-content">
+                          <span className="address-item-label">{addr.label}</span>
+                          <span className="address-item-value">{addr.value}</span>
+                        </div>
+                      </label>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="address-empty">
+                    Bạn chưa lưu địa chỉ nào. Hãy thêm địa chỉ mới bên dưới để sử dụng nhanh.
+                  </p>
+                )}
+
+                {addressError && <p className="address-error">{addressError}</p>}
+
+                {isAddingAddress ? (
+                  <div className="new-address-form">
+                    <input
+                      type="text"
+                      placeholder="Tên gợi nhớ (ví dụ: Nhà, Công ty)"
+                      value={newAddressLabel}
+                      onChange={(e) => setNewAddressLabel(e.target.value)}
+                    />
+                    <textarea
+                      placeholder="Nhập địa chỉ mới chi tiết..."
+                      value={newAddress}
+                      onChange={(e) => setNewAddress(e.target.value)}
+                      rows={2}
+                    />
+                    <div className="new-address-actions">
+                      <button type="button" onClick={handleAddNewAddress}>
+                        Lưu địa chỉ
+                      </button>
+                      <button type="button" className="secondary" onClick={handleCancelNewAddress}>
+                        Hủy
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    className="add-address-btn"
+                    onClick={() => {
+                      setIsAddingAddress(true);
+                      setAddressError("");
+                    }}
+                  >
+                    + Thêm địa chỉ mới
+                  </button>
+                )}
+              </>
+            )}
+
+            <label className="address-input-label" htmlFor="address-input">
+              Địa chỉ giao hàng chi tiết
+            </label>
+            <input
+              id="address-input"
+              type="text"
+              name="address"
+              value={form.address}
+              onChange={handleChange}
+              placeholder="Nhập địa chỉ giao hàng chi tiết..."
+              className="address-input"
+            />
             <iframe
               title="map"
               src={`https://maps.google.com/maps?q=${encodeURIComponent(form.address)}&t=&z=15&ie=UTF8&iwloc=&output=embed`}

--- a/web/src/components/OrderHistory.css
+++ b/web/src/components/OrderHistory.css
@@ -136,7 +136,9 @@
   color: white;
 }
 
-.status-tag.đang-xử-lý {
+.status-tag.đang-xử-lý,
+.status-tag.chờ-xử-lí,
+.status-tag.chờ-xử-lý {
   background-color: #ff5116;
   /* cam */
   color: white;

--- a/web/src/components/OrderHistory.jsx
+++ b/web/src/components/OrderHistory.jsx
@@ -38,8 +38,9 @@ function OrderHistory() {
                         return {
                             id: doc.id, // Lấy ID của document
                             ...data,    // Lấy tất cả các field khác
+                            status: data.status || "Chờ xử lý",
                             // Chuyển đổi Firestore Timestamp thành Javascript Date object nếu tồn tại
-                            date: data.createdAt?.toDate() 
+                            date: data.createdAt?.toDate()
                         };
                     });
                     setOrders(userOrders);

--- a/web/src/components/Product.jsx
+++ b/web/src/components/Product.jsx
@@ -33,7 +33,7 @@ function Product({ product, onAdd }) {
             <div className="prd-actions">
                 <button
                     className="prd-add-btn"
-                    onClick={() => onAdd(product)}
+                    onClick={() => onAdd(product, 1)}
                 >
                     🛒 Thêm vào giỏ
                 </button>

--- a/web/src/components/ProductDetail.css
+++ b/web/src/components/ProductDetail.css
@@ -86,6 +86,55 @@
   color: #444;
 }
 
+.productDetail__quantity {
+  margin-top: 24px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  font-weight: 600;
+  color: #333;
+}
+
+.quantity__controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: #fff5eb;
+  border-radius: 999px;
+  padding: 6px 12px;
+  border: 1px solid #ffd6b3;
+}
+
+.quantity__controls button {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: none;
+  background: linear-gradient(120deg, #ff8a3d, #ff5f2d);
+  color: #fff;
+  font-size: 1.2rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.2s ease;
+}
+
+.quantity__controls button:hover {
+  transform: translateY(-1px);
+}
+
+.quantity__controls input {
+  width: 60px;
+  text-align: center;
+  border: none;
+  background: transparent;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #333;
+  outline: none;
+}
+
 .productDetail__ingredients {
   background: #fff5eb;
   padding: 16px 20px;

--- a/web/src/components/ProductDetail.jsx
+++ b/web/src/components/ProductDetail.jsx
@@ -11,6 +11,7 @@ function ProductDetail({ onAdd }) {
     const [restaurant, setRestaurant] = useState(null);
     const [relatedProducts, setRelatedProducts] = useState([]);
     const [loading, setLoading] = useState(true);
+    const [quantity, setQuantity] = useState(1);
 
     useEffect(() => {
         const fetchProductDetail = async () => {
@@ -39,6 +40,7 @@ function ProductDetail({ onAdd }) {
                 setLoading(false);
             }
         };
+        setQuantity(1);
         fetchProductDetail();
     }, [id]);
 
@@ -117,14 +119,46 @@ function ProductDetail({ onAdd }) {
                         </div>
                     )}
 
+                    <div className="productDetail__quantity">
+                        <span>Số lượng:</span>
+                        <div className="quantity__controls">
+                            <button
+                                type="button"
+                                onClick={() => setQuantity((prev) => (prev > 1 ? prev - 1 : 1))}
+                                aria-label="Giảm số lượng"
+                            >
+                                −
+                            </button>
+                            <input
+                                type="number"
+                                min="1"
+                                value={quantity}
+                                onChange={(e) => {
+                                    const value = Number(e.target.value);
+                                    setQuantity(Number.isFinite(value) && value > 0 ? Math.floor(value) : 1);
+                                }}
+                            />
+                            <button
+                                type="button"
+                                onClick={() => setQuantity((prev) => prev + 1)}
+                                aria-label="Tăng số lượng"
+                            >
+                                +
+                            </button>
+                        </div>
+                    </div>
+
                     <button
                         className="productDetail__addBtn"
                         onClick={() =>
-                            onAdd({
-                                ...product,
-                                restaurantId: product.restaurantId || null,
-                                restaurantName: restaurant?.name || "Chưa xác định",
-                            })
+                            onAdd(
+                                {
+                                    ...product,
+                                    restaurantId: product.restaurantId || null,
+                                    restaurantName: restaurant?.name || "Chưa xác định",
+                                },
+                                quantity
+                            )
                         }
                     >
                         🛒 Thêm vào giỏ hàng
@@ -164,11 +198,14 @@ function ProductDetail({ onAdd }) {
                                         className="relatedProducts__addBtn"
                                         onClick={(e) => {
                                             e.preventDefault();
-                                            onAdd({
-                                                ...item,
-                                                restaurantId: item.restaurantId || null,
-                                                restaurantName: "N/A"
-                                            });
+                                            onAdd(
+                                                {
+                                                    ...item,
+                                                    restaurantId: item.restaurantId || null,
+                                                    restaurantName: "N/A"
+                                                },
+                                                1
+                                            );
                                         }}
                                     >
                                         🛒 Thêm

--- a/web/src/components/RestaurantDashboard.jsx
+++ b/web/src/components/RestaurantDashboard.jsx
@@ -187,7 +187,12 @@ export default function RestaurantDashboard() {
         return <span className="badge done">Đã giao</span>;
       }
     }
-    if (s === "confirmed" || s.includes("xử lý") || s.includes("processing")) {
+    if (
+      s === "confirmed" ||
+      s.includes("xử lý") ||
+      s.includes("processing") ||
+      (s.includes("chờ") && s.includes("xử"))
+    ) {
       return <span className="badge pending">Đang xử lý</span>;
     }
     return <span className="badge other">{status}</span>;
@@ -209,7 +214,7 @@ export default function RestaurantDashboard() {
             onChange={(e) => setStatusFilter(e.target.value)}
           >
             <option value="all">Tất cả</option>
-            <option value="processing">Đang xử lý</option>
+            <option value="processing">Đang/Chờ xử lý</option>
             <option value="delivering">Đang giao</option>
             <option value="delivered">Đã giao</option>
             <option value="other">Chờ xác nhận</option>

--- a/web/src/components/RestaurantDetail.jsx
+++ b/web/src/components/RestaurantDetail.jsx
@@ -59,7 +59,7 @@ function RestaurantDetail({ onAdd }) {
       ...product,
       restaurantId: restaurant.id,
       restaurantName: restaurant.name,
-    });
+    }, 1);
   };
 
   if (loading) return <p className="loading">⏳ Đang tải dữ liệu...</p>;

--- a/web/src/components/RestaurantOrders.jsx
+++ b/web/src/components/RestaurantOrders.jsx
@@ -70,6 +70,7 @@ export default function RestaurantOrders() {
   const renderStatus = (status) => {
     switch (status) {
       case "Chờ xác nhận":
+      case "Chờ xử lý":
         return <span className="rso-status rso-wait">🟡 {status}</span>;
       case "Đang giao":
         return <span className="rso-status rso-shipping">🔵 {status}</span>;
@@ -90,6 +91,7 @@ export default function RestaurantOrders() {
           <label>Trạng thái</label>
           <select value={statusFilter} onChange={(e) => setStatusFilter(e.target.value)}>
             <option value="all">Tất cả</option>
+            <option value="Chờ xử lý">Chờ xử lý</option>
             <option value="Chờ xác nhận">Chờ xác nhận</option>
             <option value="Đang giao">Đang giao</option>
             <option value="Đã giao">Đã giao</option>

--- a/web/src/components/SellerOrders.jsx
+++ b/web/src/components/SellerOrders.jsx
@@ -10,10 +10,14 @@ function SellerOrders() {
     const fetchOrders = async () => {
       try {
         const querySnapshot = await getDocs(collection(db, "orders"));
-        const data = querySnapshot.docs.map((doc) => ({
-          id: doc.id,
-          ...doc.data(),
-        }));
+        const data = querySnapshot.docs.map((doc) => {
+          const payload = doc.data();
+          return {
+            id: doc.id,
+            ...payload,
+            status: payload.status || "Chờ xử lý",
+          };
+        });
         setOrders(data);
       } catch (err) {
         console.error("❌ Lỗi lấy đơn hàng:", err);
@@ -40,6 +44,22 @@ function SellerOrders() {
     } catch (err) {
       console.error("❌ Lỗi cập nhật trạng thái:", err);
     }
+  };
+
+  const formatOrderDate = (order) => {
+    if (order?.createdAt?.toDate) {
+      return order.createdAt.toDate().toLocaleString("vi-VN");
+    }
+    if (order?.createdAt?.seconds) {
+      return new Date(order.createdAt.seconds * 1000).toLocaleString("vi-VN");
+    }
+    if (order?.date?.seconds) {
+      return new Date(order.date.seconds * 1000).toLocaleString("vi-VN");
+    }
+    if (order?.date) {
+      return new Date(order.date).toLocaleString("vi-VN");
+    }
+    return "—";
   };
 
   return (
@@ -73,16 +93,18 @@ function SellerOrders() {
                   ))}
                 </td>
                 <td>{order.total?.toLocaleString()}₫</td>
-                <td>{new Date(order.date?.seconds * 1000).toLocaleString()}</td>
+                <td>{formatOrderDate(order)}</td>
                 <td>{order.customer?.address}</td>
                 <td>
                   <select
                     value={order.status}
                     onChange={(e) => updateStatus(order.id, e.target.value)}
                   >
+                    <option value="Chờ xử lý">Chờ xử lý</option>
                     <option value="Đang xử lý">Đang xử lý</option>
                     <option value="Đã xử lý">Đã xử lý</option>
                     <option value="Đang giao">Đang giao</option>
+                    <option value="Đang giao bằng drone">Đang giao bằng drone</option>
                     <option value="Đã giao">Đã giao</option>
                   </select>
                 </td>


### PR DESCRIPTION
## Summary
- add quantity controls and total preview when adding items from the mobile product detail screen
- let mobile checkout manage delivery addresses with selection, creation, and Firestore persistence while storing new orders with contact details and "Chờ xử lý" status
- extend the mobile auth context with an `updateUser` helper so the active address stays in sync across the app

## Testing
- npm run lint *(mobile)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ed3fd0da88332a7c599fdfd078521)