### PR TITLE
Add web stub for NotificationCalendarCommand

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -5,6 +5,8 @@ import { AuthProvider } from "../libs/AuthContext";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { CartProvider } from "../libs/CartContext";
 
+import "../polyfills/registerNotificationCalendarCommand";
+
 export default function RootLayout() {
   return (
     <SafeAreaProvider>

--- a/mobile/polyfills/registerNotificationCalendarCommand.ts
+++ b/mobile/polyfills/registerNotificationCalendarCommand.ts
@@ -1,0 +1,2 @@
+// Native platforms do not need a stub for NotificationCalendarCommand.
+export {};

--- a/mobile/polyfills/registerNotificationCalendarCommand.web.ts
+++ b/mobile/polyfills/registerNotificationCalendarCommand.web.ts
@@ -1,0 +1,39 @@
+const MODULE_NAME = 'native/NotificationCalendarCommand';
+
+type ExpoGlobal = {
+  modules?: Record<string, any>;
+};
+
+if (typeof globalThis !== 'undefined') {
+  const globalScope = globalThis as typeof globalThis & { expo?: ExpoGlobal };
+  const expoGlobal: ExpoGlobal = (globalScope.expo = globalScope.expo ?? {});
+  const modules: Record<string, any> = (expoGlobal.modules = expoGlobal.modules ?? {});
+
+  if (!modules[MODULE_NAME]) {
+    const noop = (method: string) => (..._args: unknown[]) => {
+      if (typeof console !== 'undefined' && console.warn) {
+        console.warn(
+          `[notification-calendar] Native method "${method}" is not available on web. The call was ignored.`,
+        );
+      }
+      return null;
+    };
+
+    modules[MODULE_NAME] = new Proxy(
+      { name: 'NotificationCalendarCommand' },
+      {
+        get(target, property) {
+          if (property in target) {
+            return (target as any)[property];
+          }
+          if (property === Symbol.toStringTag) {
+            return 'NotificationCalendarCommand';
+          }
+          return noop(String(property));
+        },
+      },
+    );
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- register a lightweight web stub for `native/NotificationCalendarCommand` so Expo web can ignore unavailable notification APIs instead of crashing
- load the stub during app initialization to ensure the module is present before other screens mount

## Testing
- `EXPO_OFFLINE=1 npx expo export --platform web`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914af154aa08332a2b0cdc4ba2c40f9)